### PR TITLE
Adds "Group search mode" in settings  and "Overwrite with current Jobs" button in presets Jobs tab.

### DIFF
--- a/BetterPartyFinder/Configuration.cs
+++ b/BetterPartyFinder/Configuration.cs
@@ -16,6 +16,8 @@ public class Configuration : IPluginConfiguration
     public bool ShowWhenPfOpen { get; set; }
     public WindowSide WindowSide { get; set; } = WindowSide.Left;
 
+    public bool GroupSearchMode { get; set; } 
+
     internal static Configuration? Load()
     {
         return (Configuration?) Plugin.Interface.GetPluginConfig();

--- a/BetterPartyFinder/Plugin.cs
+++ b/BetterPartyFinder/Plugin.cs
@@ -24,6 +24,8 @@ public class Plugin : IDalamudPlugin
     [PluginService] public static IAddonLifecycle AddonLifecycle { get; private set; } = null!;
     [PluginService] public static IPluginLog Log { get; private set; } = null!;
 
+    [PluginService] public static IPartyList PartyList { get; private set; } = null!;
+
     public readonly WindowSystem WindowSystem = new(Name);
     public ConfigWindow ConfigWindow { get; init; }
     public MainWindow MainWindow { get; init; }

--- a/BetterPartyFinder/Util.cs
+++ b/BetterPartyFinder/Util.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.Gui.PartyFinder.Types;
 using Lumina.Excel.Sheets;
 
 namespace BetterPartyFinder;
@@ -32,5 +33,107 @@ public static class Util
     {
         var dcRow = character.HomeWorld.Value.DataCenter.RowId;
         return Plugin.DataManager.GetExcelSheet<World>().Where(world => world.IsPublic && world.DataCenter.RowId == dcRow);
+    }
+
+    internal static JobFlags GetJobFlagsForClassJob(ClassJob classJob)
+    {
+        var jobFlags = new JobFlags();
+        switch (classJob.Abbreviation.ExtractText())
+        {
+            case "GLD":
+                jobFlags = JobFlags.Gladiator;
+                break;
+            case "PGL":
+                jobFlags = JobFlags.Pugilist;
+                break;
+            case "MRD":
+                jobFlags = JobFlags.Marauder;
+                break;
+            case "LNC":
+                jobFlags = JobFlags.Lancer;
+                break;
+            case "ARC":
+                jobFlags = JobFlags.Archer;
+                break;
+            case "CNJ":
+                jobFlags = JobFlags.Conjurer;
+                break;
+            case "THM":
+                jobFlags = JobFlags.Thaumaturge;
+                break;
+            case "PLD":
+                jobFlags = JobFlags.Paladin;
+                break;
+            case "MNK":
+                jobFlags = JobFlags.Monk;
+                break;
+            case "WAR":
+                jobFlags = JobFlags.Warrior;
+                break;
+            case "DRG":
+                jobFlags = JobFlags.Dragoon;
+                break;
+            case "BRD":
+                jobFlags = JobFlags.Bard;
+                break;
+            case "WHM":
+                jobFlags = JobFlags.WhiteMage;
+                break;
+            case "BLM":
+                jobFlags = JobFlags.BlackMage;
+                break;
+            case "ACN":
+                jobFlags = JobFlags.Arcanist;
+                break;
+            case "SMN":
+                jobFlags = JobFlags.Summoner;
+                break;
+            case "SCH":
+                jobFlags = JobFlags.Scholar;
+                break;
+            case "ROG":
+                jobFlags = JobFlags.Rogue;
+                break;
+            case "NIN":
+                jobFlags = JobFlags.Ninja;
+                break;
+            case "MCH":
+                jobFlags = JobFlags.Machinist;
+                break;
+            case "DRK":
+                jobFlags = JobFlags.DarkKnight;
+                break;
+            case "AST":
+                jobFlags = JobFlags.Astrologian;
+                break;
+            case "SAM":
+                jobFlags = JobFlags.Samurai;
+                break;
+            case "RDM":
+                jobFlags = JobFlags.RedMage;
+                break;
+            case "BLU":
+                jobFlags = JobFlags.BlueMage;
+                break;
+            case "GNB":
+                jobFlags = JobFlags.Gunbreaker;
+                break;
+            case "DNC":
+                jobFlags = JobFlags.Dancer;
+                break;
+            case "RPR":
+                jobFlags = JobFlags.Reaper;
+                break;
+            case "SGE":
+                jobFlags = JobFlags.Sage;
+                break;
+            case "VPR":
+                jobFlags = JobFlags.Viper;
+                break;
+            case "PCT":
+                jobFlags = JobFlags.Pictomancer;
+                break;
+        }
+        return jobFlags;
     }
 }

--- a/BetterPartyFinder/Windows/Config/ConfigWindow.General.cs
+++ b/BetterPartyFinder/Windows/Config/ConfigWindow.General.cs
@@ -18,6 +18,13 @@ public partial class ConfigWindow
             Plugin.Config.Save();
         }
 
+        var groupSearchMode = Plugin.Config.GroupSearchMode;
+        if (ImGui.Checkbox("Group search mode(Ignores preset Jobs, uses active party members ClassJobs or own ClassJob", ref groupSearchMode))
+        {
+            Plugin.Config.GroupSearchMode = groupSearchMode;
+            Plugin.Config.Save();
+        }
+
         var sideOptions = new[]
         {
             "Left",

--- a/BetterPartyFinder/Windows/Main/MainWindow.Jobs.cs
+++ b/BetterPartyFinder/Windows/Main/MainWindow.Jobs.cs
@@ -21,6 +21,13 @@ public partial class MainWindow
             Plugin.Config.Save();
         }
 
+        if (ImGui.Button("Overwrite with current Jobs"))
+        {
+            filter.Jobs = Util.GetCurrentPartyJobs();
+            Plugin.Config.Save();
+        }
+
+
         var toRemove = new HashSet<int>();
         for (var i = 0; i < filter.Jobs.Count; i++)
         {


### PR DESCRIPTION
- Adds a feature to search using current party composition instead of the active preset's jobs list
- Adds a button to the presets "Jobs" tab to replace the preset's selected jobs with the active party composition. 
![image](https://github.com/user-attachments/assets/9766f50a-2ea5-4237-aba9-c64b714c85f7)
