### PR TITLE
Add filtering of listings with no LootRuleFlags

### DIFF
--- a/BetterPartyFinder/Configuration.cs
+++ b/BetterPartyFinder/Configuration.cs
@@ -44,6 +44,7 @@ public class ConfigurationFilter
     // use nosol if trying to avoid spam
 
     public SearchAreaFlags SearchArea { get; set; } = (SearchAreaFlags) ~(uint) 0;
+    public bool NoLootRule { get; set; } = true;
     public LootRuleFlags LootRule { get; set; } = ~LootRuleFlags.None;
     public DutyFinderSettingsFlags DutyFinderSettings { get; set; } = ~DutyFinderSettingsFlags.None;
     public ConditionFlags Conditions { get; set; } = (ConditionFlags) ~(uint) 0;

--- a/BetterPartyFinder/Filter.cs
+++ b/BetterPartyFinder/Filter.cs
@@ -91,26 +91,32 @@ public class Filter : IDisposable
             return false;
         }
 
-        if (!listing[filter.LootRule])
+        if (listing.LootRules == 0 && !filter.NoLootRule)
         {
             Plugin.Log.Verbose("early exit 6");
             return false;
         }
 
-        if (((listing.DutyFinderSettings ^ filter.DutyFinderSettings) & ~filter.DutyFinderSettings) > 0) {
+        if (!listing[filter.LootRule])
+        {
             Plugin.Log.Verbose("early exit 7");
+            return false;
+        }
+
+        if (((listing.DutyFinderSettings ^ filter.DutyFinderSettings) & ~filter.DutyFinderSettings) > 0) {
+            Plugin.Log.Verbose("early exit 8");
             return false;
         }
 
         if (!listing[filter.Conditions])
         {
-            Plugin.Log.Verbose("early exit 8");
+            Plugin.Log.Verbose("early exit 9");
             return false;
         }
 
         if (!listing[filter.Objectives])
         {
-            Plugin.Log.Verbose("early exit 9");
+            Plugin.Log.Verbose("early exit 10");
             return false;
         }
 
@@ -119,7 +125,7 @@ public class Filter : IDisposable
         {
             if (!filter.Keywords.CheckDescription(listing.Description.TextValue))
             {
-                Plugin.Log.Verbose("early exit 10");
+                Plugin.Log.Verbose("early exit 11");
                 return false;
             }
         }

--- a/BetterPartyFinder/Windows/Main/MainWindow.Restrictions.cs
+++ b/BetterPartyFinder/Windows/Main/MainWindow.Restrictions.cs
@@ -47,7 +47,8 @@ public partial class MainWindow
 
         DrawSeparator();
 
-        filter[LootRuleFlags.GreedOnly] = DrawRestrictionEntry("Greed Only", filter[LootRuleFlags.GreedOnly]);
+        filter.NoLootRule = DrawRestrictionEntry("No Loot Rule", filter.NoLootRule);
+		filter[LootRuleFlags.GreedOnly] = DrawRestrictionEntry("Greed Only", filter[LootRuleFlags.GreedOnly]);
         filter[LootRuleFlags.Lootmaster] = DrawRestrictionEntry("Lootmaster", filter[LootRuleFlags.Lootmaster]);
 
         DrawSeparator();


### PR DESCRIPTION
Currently, BPF has no way of filtering parties with no loot rules due to how `LootRuleFlags` is defined.

Having the ability to exclude parties with no loot rule is useful for people doing savage merc runs, excluding all parties not set as Lootmaster (as an example).

This PR adds this as a new option in the form of a boolean (since there is no `LootRuleFlags.None` flag). There's probably a better way to implement it, but this worked for me and seemed relatively simple.