### PR TITLE
Filter Fix

### DIFF
--- a/BetterPartyFinder/Filter.cs
+++ b/BetterPartyFinder/Filter.cs
@@ -209,10 +209,7 @@ public class Filter : IDisposable
                     if (a.Intersect(b).Count() != 1)
                         continue;
 
-                    // if there is overlap, check the difference between the sets
-                    // if there is no difference, the party can't be joined
-                    // note that if the overlap is more than one slot, we don't need to check
-                    if (!a.Except(b).Any())
+                    if (!a.Except(b).Any() && !b.Except(a).Any())
                         return false;
                 }
             }


### PR DESCRIPTION
This PR fixes an order-dependent bug in the party-slot feasibility check.

Previously the code rejected a pair of filtered jobs when one job’s candidate-slot set was a subset of the other:

```
if (!a.Except(b).Any())
    return false;
```
That means a filter could fail depending on which job was evaluated as a vs b, even when a valid slot assignment exists.

Example :
Assume a PF listing has 4 DPS slots. One DPS slot is restricted to Melee only, while the other slots accept Any DPS.

Filter jobs: MCH (Ranged Physical) and PCT (Caster)

Candidate slots:

MCH can only join {Slot 2} (the listing only allows Phys Ranged in that one slot)

PCT can join {Slot 1, Slot 2} (caster allowed in multiple DPS slots)

A valid assignment exists (MCH → Slot 2, PCT → Slot 1).
But if MCH is evaluated as a and PCT as b, then a ⊆ b holds and the old logic incorrectly rejects the listing. If the filter order is swapped, it may pass hence order dependence.

Fix: make the subset check symmetric, rejecting only when both sets are equal (mutual subset), i.e. both jobs have exactly the same candidate slots:

```
if (!a.Except(b).Any() && !b.Except(a).Any())
    return false;
```

This removes order sensitivity while still catching the real conflict case (two jobs forced into the same single slot).